### PR TITLE
Add Pagination in search page

### DIFF
--- a/client/components/Search/Pagination.js
+++ b/client/components/Search/Pagination.js
@@ -1,0 +1,27 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Row, Pagination as AntdPagination } from 'antd';
+
+export default class Pagination extends PureComponent {
+  render() {
+    const { currentPage, onChange, total } = this.props;
+
+    return (
+      <Row type="flex" justify="center">
+        <AntdPagination
+          onChange={onChange}
+          current={currentPage}
+          pageSize={20}
+          total={total}
+          style={{ marginTop: '80px' }}
+        />
+      </Row>
+    );
+  }
+}
+
+Pagination.propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+};

--- a/client/components/Search/VideosQuery.js
+++ b/client/components/Search/VideosQuery.js
@@ -19,8 +19,14 @@ const QUERY = gql`
         img_url
         code
         total_view_count
+        videos {
+          source
+          url
+          view_count
+        }
+        score
+        length
         tags
-        publishedAt
       }
     }
   }

--- a/client/components/Search/VideosQuery.js
+++ b/client/components/Search/VideosQuery.js
@@ -4,8 +4,13 @@ import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 
 const QUERY = gql`
-  query searchVideos($keyword: String!, $sort: String!, $models: [String]!) {
-    searchVideos(keyword: $keyword, sort: $sort, models: $models) {
+  query searchVideos(
+    $keyword: String!
+    $sort: String!
+    $models: [String]!
+    $page: Int!
+  ) {
+    searchVideos(keyword: $keyword, sort: $sort, models: $models, page: $page) {
       total
       results {
         _id
@@ -37,7 +42,12 @@ VideosQuery.propTypes = {
 };
 
 export default graphql(QUERY, {
-  options: ({ keyword = '', sort = 'total_view_count', models = [] }) => ({
-    variables: { keyword, sort, models },
+  options: ({
+    keyword = '',
+    sort = 'total_view_count',
+    models = [],
+    page = 1,
+  }) => ({
+    variables: { keyword, sort, models, page: page - 1 },
   }),
 })(VideosQuery);

--- a/client/components/Search/index.js
+++ b/client/components/Search/index.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import queryString from 'query-string';
 
+import { Router } from '../../routes';
+
 import Filter from './Filter';
 import Videos from './Videos';
+import Pagination from './Pagination';
 import VideosQuery from './VideosQuery';
 
 const SearchSection = styled.section`
@@ -27,23 +30,40 @@ const FilterSection = styled.section`
 
 class Search extends Component {
   state = {
-    sort: 'total_view_count',
     models: [],
+    page: 1,
+    sort: 'total_view_count',
   };
 
   componentWillMount() {
-    const { sort } = queryString.parse(this.props.url.query.filter);
+    // 之後會有更多 filter
+    const { page, filter } = this.props.url.query;
+    const { sort } = queryString.parse(filter);
 
     this.setState(prevState => ({
       ...prevState,
-      sort: sort || 'total_view_count',
+      sort: sort || prevState.sort,
+      page: parseInt(page, 10) || prevState.page,
     }));
+  }
+
+  componentDidMount() {
+    const { keyword, page } = this.props.url.query;
+
+    if (!page) {
+      Router.pushRoute(
+        'search',
+        { keyword: decodeURI(keyword), page: 1 },
+        { shallow: true }
+      );
+    }
   }
 
   onSortChange = value => {
     this.setState(prevState => ({
       ...prevState,
       sort: value,
+      page: 1,
     }));
   };
 
@@ -56,7 +76,7 @@ class Search extends Component {
 
   render() {
     const keyword = decodeURI(this.props.url.query.keyword);
-    const { sort, models } = this.state;
+    const { page, sort, models } = this.state;
 
     return (
       <SearchSection>
@@ -75,12 +95,34 @@ class Search extends Component {
           </VideosQuery>
         </FilterSection>
         <VideosSection>
-          <VideosQuery keyword={keyword} sort={sort} models={models}>
+          <VideosQuery
+            keyword={keyword}
+            sort={sort}
+            models={models}
+            page={page}
+          >
             {({ searchVideos: { total, results } }) => [
               <p key="total">
                 有 <b>{total}</b> 項結果
               </p>,
               <Videos videos={results} key="videos" />,
+              <Pagination
+                currentPage={page}
+                total={total}
+                onChange={p => {
+                  Router.pushRoute(
+                    'search',
+                    { keyword, page: p },
+                    { shallow: true }
+                  );
+
+                  this.setState(prevState => ({
+                    ...prevState,
+                    page: p,
+                  }));
+                }}
+                key="pagination"
+              />,
             ]}
           </VideosQuery>
         </VideosSection>

--- a/client/components/shared/SearchInput.js
+++ b/client/components/shared/SearchInput.js
@@ -42,7 +42,7 @@ class SearchInput extends Component {
   handleClick = () => {
     Router.pushRoute(
       'search',
-      { keyword: this.state.value },
+      { keyword: this.state.value, page: 1 },
       { shallow: true }
     );
   };

--- a/client/components/shared/VideosRow.js
+++ b/client/components/shared/VideosRow.js
@@ -4,7 +4,6 @@ import { Col, Card, Tag } from 'antd';
 import format from 'date-fns/format';
 import createHistory from 'history/createBrowserHistory';
 
-import VideoQuery from '../Video/VideoQuery';
 import VideoModal from '../Video/VideoModal';
 
 let history;
@@ -64,27 +63,36 @@ class VideosRow extends Component {
 
     return videos.map(
       ({
+        _id,
         code,
         img_url: imgURL,
         title,
         publishedAt,
         models,
         tags,
+        length,
+        score,
         total_view_count: totalViewCount,
       }) => (
         <Col span={colSpan} key={code} style={{ padding: '5px' }}>
-          <VideoQuery code={code}>
-            {({ video: data }) => (
-              <VideoModal
-                data={data}
-                visible={showModal[code] || false}
-                toggleShowModal={() => {
-                  this.toggleShowModal(code);
-                  history.goBack();
-                }}
-              />
-            )}
-          </VideoQuery>
+          <VideoModal
+            data={{
+              _id,
+              code,
+              title,
+              img_url: imgURL,
+              models,
+              videos,
+              tags,
+              length,
+              score,
+            }}
+            visible={showModal[code] || false}
+            toggleShowModal={() => {
+              this.toggleShowModal(code);
+              history.goBack();
+            }}
+          />
           <Card
             hoverable
             cover={<img alt={code} src={imgURL} />}

--- a/client/components/shared/VideosRow.js
+++ b/client/components/shared/VideosRow.js
@@ -77,7 +77,7 @@ class VideosRow extends Component {
             {({ video: data }) => (
               <VideoModal
                 data={data}
-                visible={showModal[code]}
+                visible={showModal[code] || false}
                 toggleShowModal={() => {
                   this.toggleShowModal(code);
                   history.goBack();

--- a/client/routes.js
+++ b/client/routes.js
@@ -3,7 +3,7 @@ const nextRoutes = require('next-routes');
 const routes = nextRoutes();
 
 routes.add('index', '/');
-routes.add('search', '/s/:keyword/:filter*');
+routes.add('search', '/s/:keyword/:page*/:filter*');
 routes.add('video', '/video/:code');
 routes.add('about');
 routes.add('bot');

--- a/server/src/schema/resolvers/searchVideos.js
+++ b/server/src/schema/resolvers/searchVideos.js
@@ -3,7 +3,7 @@ import set from 'lodash/set';
 
 import { getMongoDatabase, getElasticsearchDatabase } from '../../database';
 
-const PAGE_VIDEOS_NUMBER = 12;
+const PAGE_VIDEOS_NUMBER = 20;
 
 export default async (obj, args) => {
   const { days, models, tags, sources, sort, page, keyword } = args;


### PR DESCRIPTION
無限捲軸做不出來，只好用簡單的分頁ＱＱ
另外我在測試的時候，後端排序後的結果回傳好像不太正確， @LittleWhiteYA  你再幫看一下
搜尋頁的前端 routing 改成 `/s/:keyword/:page*/:filter*`，所以基本會出現 `http://localhost:3000/s/乳/1` 這樣
<img width="1265" alt="screen shot 2018-03-03 at 4 57 47 pm" src="https://user-images.githubusercontent.com/12113222/36932467-3ea48a76-1f04-11e8-968d-73e8e913b627.png">
